### PR TITLE
feat(p2p): introduce `PreconfGossipRuntimeConfig` interface

### DIFF
--- a/op-node/p2p/gossip.go
+++ b/op-node/p2p/gossip.go
@@ -61,6 +61,10 @@ type GossipRuntimeConfig interface {
 	P2PSequencerAddress() common.Address
 }
 
+type PreconfGossipRuntimeConfig interface {
+	P2PSequencerAddresses() []common.Address
+}
+
 //go:generate mockery --name GossipMetricer
 type GossipMetricer interface {
 	RecordGossipEvent(evType int32)
@@ -534,6 +538,29 @@ func verifyBlockSignature(log log.Logger, cfg *rollup.Config, runCfg GossipRunti
 		return pubsub.ValidationReject
 	}
 	addr := crypto.PubkeyToAddress(*pub)
+
+	// CHANGE(taiko): check if the signer is in the whitelist.
+	if cfg, ok := runCfg.(PreconfGossipRuntimeConfig); ok {
+		// If there are no configured p2p sequencer addresses, accept the block.
+		if len(cfg.P2PSequencerAddresses()) == 0 {
+			log.Warn("no configured p2p sequencer addresses", "peer", id, "addr", addr)
+			return pubsub.ValidationAccept
+		}
+
+		// If the signer is in the whitelist, accept the block.
+		for _, expected := range cfg.P2PSequencerAddresses() {
+			// If the signer is an empty address, accept the block.
+			if expected == (common.Address{}) {
+				log.Warn("empty no configured p2p sequencer address", "peer", id, "addr", addr)
+				return pubsub.ValidationAccept
+			} else if addr == expected {
+				return pubsub.ValidationAccept
+			}
+		}
+
+		log.Warn("unexpected block authors", "err", err, "peer", id, "addrs", cfg.P2PSequencerAddresses())
+		return pubsub.ValidationReject
+	}
 
 	// In the future we may load & validate block metadata before checking the signature.
 	// And then check the signer based on the metadata, to support e.g. multiple p2p signers at the same time.

--- a/op-node/p2p/gossip.go
+++ b/op-node/p2p/gossip.go
@@ -542,6 +542,7 @@ func verifyBlockSignature(log log.Logger, cfg *rollup.Config, runCfg GossipRunti
 	// CHANGE(taiko): check if the signer is in the whitelist.
 	if cfg, ok := runCfg.(PreconfGossipRuntimeConfig); ok {
 		// If there are no configured p2p sequencer addresses, accept the block.
+		// TODO: Remove this check once we have a real whitelist of sequencer addresses.
 		if len(cfg.P2PSequencerAddresses()) == 0 {
 			log.Warn("no configured p2p sequencer addresses", "peer", id, "addr", addr)
 			return pubsub.ValidationAccept
@@ -550,6 +551,7 @@ func verifyBlockSignature(log log.Logger, cfg *rollup.Config, runCfg GossipRunti
 		// If the signer is in the whitelist, accept the block.
 		for _, expected := range cfg.P2PSequencerAddresses() {
 			// If the signer is an empty address, accept the block.
+			// TODO: Remove this check once we have a real whitelist of sequencer addresses.
 			if expected == (common.Address{}) {
 				log.Warn("empty no configured p2p sequencer address", "peer", id, "addr", addr)
 				return pubsub.ValidationAccept


### PR DESCRIPTION
As discussed in nethermind-gattaca channel:

```md
It is not a "perfect" solution, as the previous preconfer can still fail to include their blocks, but it will reduce the risk of reorgs drastically while (at first glance) not introducing too much complication in the protocol/code compared to alternatives like the "next preconfer include batches of previous preconfer" thing
So say this "handover window" is X slots. Then the changes needed are:
- Current epoch preconfer stops preconfing at slot 32-X and start focusing on inclusion of your preconfed batches.
- Next epoch preconfer starts preconfign at slot 32-X of previous epoch.
- Preconf sidecars should start accepting L2 blocks preconfed by the next epoch preconfer from slot 32-X of previous epoch.
```