### PR TITLE
feat(p2p): dont use default bootnodes, change annoying logs to debug

### DIFF
--- a/op-node/p2p/cli/load_config.go
+++ b/op-node/p2p/cli/load_config.go
@@ -190,11 +190,8 @@ func loadDiscoveryOpts(conf *p2p.Config, ctx *cli.Context) error {
 		}
 		bootnodes = append(bootnodes, nodeRecord)
 	}
-	if len(bootnodes) > 0 {
-		conf.Bootnodes = bootnodes
-	} else {
-		conf.Bootnodes = p2p.DefaultBootnodes
-	}
+
+	conf.Bootnodes = bootnodes
 
 	if ctx.IsSet(flags.NetRestrictName) {
 		netRestrict, err := netutil.ParseNetlist(ctx.String(flags.NetRestrictName))

--- a/op-node/p2p/discovery.go
+++ b/op-node/p2p/discovery.go
@@ -279,7 +279,7 @@ func (n *NodeP2P) DiscoveryProcess(ctx context.Context, log log.Logger, cfg *rol
 				return
 			}
 			addrs := n.Host().Peerstore().Addrs(id)
-			log.Info("attempting connection", "peer", id)
+			log.Debug("attempting connection", "peer", id)
 			ctx, cancel := context.WithTimeout(ctx, time.Second*10)
 			err := n.Host().Connect(ctx, peer.AddrInfo{ID: id, Addrs: addrs})
 			cancel()

--- a/op-node/p2p/notifications.go
+++ b/op-node/p2p/notifications.go
@@ -29,11 +29,11 @@ func (notif *notifications) ListenClose(n network.Network, a ma.Multiaddr) {
 }
 func (notif *notifications) Connected(n network.Network, v network.Conn) {
 	notif.m.IncPeerCount()
-	notif.log.Info("connected to peer", "peer", v.RemotePeer(), "addr", v.RemoteMultiaddr())
+	notif.log.Debug("connected to peer", "peer", v.RemotePeer(), "addr", v.RemoteMultiaddr())
 }
 func (notif *notifications) Disconnected(n network.Network, v network.Conn) {
 	notif.m.DecPeerCount()
-	notif.log.Info("disconnected from peer", "peer", v.RemotePeer(), "addr", v.RemoteMultiaddr())
+	notif.log.Debug("disconnected from peer", "peer", v.RemotePeer(), "addr", v.RemoteMultiaddr())
 }
 func (notif *notifications) OpenedStream(n network.Network, v network.Stream) {
 	notif.m.IncStreamCount()

--- a/op-node/p2p/sync.go
+++ b/op-node/p2p/sync.go
@@ -410,7 +410,7 @@ func (s *SyncClient) mainLoop() {
 			s.log.Info("Checking in flight", "num", check.num)
 			check.result <- s.inFlight.get(check.num)
 		case <-s.resCtx.Done():
-			s.log.Info("stopped P2P req-resp L2 block sync client")
+			s.log.Warn("stopped P2P req-resp L2 block sync client")
 			return
 		}
 	}
@@ -560,7 +560,7 @@ func (s *SyncClient) peerLoop(ctx context.Context, id peer.ID) {
 	}()
 
 	log := s.log.New("peer", id)
-	log.Info("Starting P2P sync client event loop")
+	log.Debug("Starting P2P sync client event loop")
 
 	// Implement the same rate limits as the server does per-peer,
 	// so we don't be too aggressive to the server.


### PR DESCRIPTION
after some changes, this library does not work without passing in a garbage `--p2p.bootnodes` flag, since it uses the defaults, which we don't even want (if we use no bootnodes, just a static peer):

```ts
failed to start discv5: bad bootstrap node "enode://d25ce99435982b04d60c4b41ba256b84b888626db7bee45a9419382300fbe907359ae5ef250346785bff8d3b9d07cd3e017a27e2ee3cfda3bcbb0ba762ac9674@bootnode.conduit.xyz:0?discport=30301": missing IP address
```

it is better if we just don't set any defaults.

As well ,the logs are annoying and frequent.