### PR TITLE
fix(gossip): fix ability to spam

### DIFF
--- a/op-node/p2p/gossip.go
+++ b/op-node/p2p/gossip.go
@@ -28,6 +28,9 @@ import (
 )
 
 const (
+	window       = 45 * time.Second // CHANGE(taiko): window for accepting the same hash
+	refillPerMin = 200              // CHANGE(taiko): tokens/min per peer
+	maxTokens    = refillPerMin     // CHANGE(taiko): max tokens per peer
 	// maxGossipSize limits the total size of gossip RPC containers as well as decompressed individual messages.
 	maxGossipSize = 10 * (1 << 20)
 	// minGossipSize is used to make sure that there is at least some data to validate the signature against.
@@ -541,11 +544,7 @@ func BuildPreconfBlocksRequestValidator(log log.Logger, cfg *rollup.Config, runC
 		panic(fmt.Errorf("seen‑hash LRU: %w", err))
 	}
 
-	var bucketsMu, seenMu sync.Mutex
-
-	const window = 45 * time.Second // accept same hash <= once/45s
-	const refillPerMin = 200        // tokens/min per peer (tune)
-	const maxTokens = refillPerMin
+	var bucketsMu sync.Mutex
 
 	return func(ctx context.Context, id peer.ID, message *pubsub.Message) pubsub.ValidationResult {
 		now := time.Now()
@@ -553,10 +552,8 @@ func BuildPreconfBlocksRequestValidator(log log.Logger, cfg *rollup.Config, runC
 
 		// we use a per hash time window to prevent spam
 		// of the same hash over and over.
-		seenMu.Lock()
-		defer seenMu.Unlock()
+
 		if t, ok := seenHash.Get(hash); ok && now.Sub(t) < window {
-			seenMu.Unlock()
 			return pubsub.ValidationIgnore
 		}
 
@@ -588,9 +585,7 @@ func BuildPreconfBlocksRequestValidator(log log.Logger, cfg *rollup.Config, runC
 		b.tokens--
 
 		// mark seen after passing rate limit
-		seenMu.Lock()
 		seenHash.Add(hash, now)
-		seenMu.Unlock()
 		message.ValidatorData = hash
 		return pubsub.ValidationAccept
 	}
@@ -598,6 +593,10 @@ func BuildPreconfBlocksRequestValidator(log log.Logger, cfg *rollup.Config, runC
 
 // CHANGE(taiko): add preconfBlocksRequest topic validator
 func BuildPreconfBlocksEndOfSequencingRequestValidator(log log.Logger, cfg *rollup.Config, runCfg GossipRuntimeConfig) pubsub.ValidatorEx {
+	buckets, err := lru.New[peer.ID, *rateBucket](defaultLRUCacheSize) // per‑peer token buckets
+	if err != nil {
+		panic(fmt.Errorf("per‑peer buckets: %w", err))
+	}
 	// Seen block hashes per block height
 	// uint64 -> *seenBlocks
 	epochLRU, err := lru.New[uint64, *seenEpochs](defaultLRUCacheSize)
@@ -605,7 +604,10 @@ func BuildPreconfBlocksEndOfSequencingRequestValidator(log log.Logger, cfg *roll
 		panic(fmt.Errorf("failed to set up epoch LRU cache: %w", err))
 	}
 
+	var bucketsMu sync.Mutex
+
 	return func(ctx context.Context, id peer.ID, message *pubsub.Message) pubsub.ValidationResult {
+		now := time.Now()
 		// convert message.Data to uint256
 		epoch := big.NewInt(0).SetBytes(message.Data).Uint64()
 
@@ -616,10 +618,37 @@ func BuildPreconfBlocksEndOfSequencingRequestValidator(log log.Logger, cfg *roll
 			epochLRU.Add(epoch, seen)
 		}
 
-		if count, hasSeen := seen.numSeen(epoch); hasSeen && count > 5 {
+		if count, hasSeen := seen.numSeen(epoch); hasSeen && count > maxResponsesAcceptable {
 			return pubsub.ValidationIgnore
 		}
 
+		bucketsMu.Lock()
+		defer bucketsMu.Unlock()
+		b, ok := buckets.Get(id)
+		if !ok {
+			// initialize the new rate bucket for this peer
+			b = &rateBucket{tokens: maxTokens, last: now}
+			buckets.Add(id, b)
+		} else {
+			// otherwise lets see if this bucket needs to be refilled
+			if d := now.Sub(b.last); d > 0 {
+				b.tokens += int(d.Minutes() * float64(refillPerMin))
+				if b.tokens > maxTokens {
+					b.tokens = maxTokens
+				}
+				b.last = now
+			}
+		}
+
+		// we just straight up ignore it if the bucket is empty
+		// it means this peer has sent too many requests in a short period
+		// of time.
+		if b.tokens < 1 {
+			return pubsub.ValidationIgnore
+		}
+		b.tokens--
+
+		// mark seen only after passing the rate limit
 		seen.markSeen(epoch)
 
 		message.ValidatorData = epoch

--- a/op-node/p2p/gossip.go
+++ b/op-node/p2p/gossip.go
@@ -48,6 +48,7 @@ const (
 	defaultBufferSize         = 768  // CHANGE(taiko): change sizes to contants
 	defaultLRUCacheSize       = 1000 // CHANGE(taiko): change sizes to contants
 	expectedSigLen            = 65   // CHANGE(taiko): expected signature length for the sequencer signature
+	maxResponsesAcceptable    = 3    // CHANGE(taiko): max responses acceptable for preconf blocks
 )
 
 // Message domains, the msg id function uncompresses to keep data monomorphic,
@@ -55,6 +56,12 @@ const (
 
 var MessageDomainInvalidSnappy = [4]byte{0, 0, 0, 0}
 var MessageDomainValidSnappy = [4]byte{1, 0, 0, 0}
+
+// rateBucket is used to limit the number of messages that can be sent in a given time period.
+type rateBucket struct {
+	tokens int
+	last   time.Time
+}
 
 type GossipSetupConfigurables interface {
 	PeerScoringParams() *ScoringParams
@@ -511,7 +518,7 @@ func BuildPreconfBlocksResponseValidator(
 			seen = new(seenBlocks)
 			preconfblockLRU.Add(height, seen)
 		}
-		if count, _ := seen.hasSeen(payload.BlockHash); count > 10 {
+		if count, _ := seen.hasSeen(payload.BlockHash); count > maxResponsesAcceptable {
 			log.Warn("seen same block hash too many times in preconf response", "height", payload.BlockNumber)
 			return pubsub.ValidationIgnore
 		}
@@ -525,30 +532,66 @@ func BuildPreconfBlocksResponseValidator(
 
 // CHANGE(taiko): add preconfBlocksRequest topic validator
 func BuildPreconfBlocksRequestValidator(log log.Logger, cfg *rollup.Config, runCfg GossipRuntimeConfig) pubsub.ValidatorEx {
-	// Seen block hashes per block height
-	// uint64 -> *seenBlocks
-	hashLRU, err := lru.New[common.Hash, *seenHashes](defaultLRUCacheSize)
+	buckets, err := lru.New[peer.ID, *rateBucket](defaultLRUCacheSize) // per‑peer token buckets
 	if err != nil {
-		panic(fmt.Errorf("failed to set up block height LRU cache: %w", err))
+		panic(fmt.Errorf("per‑peer buckets: %w", err))
+	}
+	seenHash, err := lru.New[common.Hash, time.Time](defaultLRUCacheSize) // per‑hash window
+	if err != nil {
+		panic(fmt.Errorf("seen‑hash LRU: %w", err))
 	}
 
+	var bucketsMu, seenMu sync.Mutex
+
+	const window = 45 * time.Second // accept same hash <= once/45s
+	const refillPerMin = 200        // tokens/min per peer (tune)
+	const maxTokens = refillPerMin
+
 	return func(ctx context.Context, id peer.ID, message *pubsub.Message) pubsub.ValidationResult {
+		now := time.Now()
 		hash := common.BytesToHash(message.Data)
 
-		seen, ok := hashLRU.Get(hash)
-		if !ok {
-			seen = new(seenHashes)
-			seen.blockHashes = make(map[common.Hash]uint64)
-			hashLRU.Add(hash, seen)
-		}
-
-		if count, hasSeen := seen.numSeen(hash); hasSeen && count > 5 {
+		// we use a per hash time window to prevent spam
+		// of the same hash over and over.
+		seenMu.Lock()
+		defer seenMu.Unlock()
+		if t, ok := seenHash.Get(hash); ok && now.Sub(t) < window {
+			seenMu.Unlock()
 			return pubsub.ValidationIgnore
 		}
 
-		seen.markSeen(hash)
-		message.ValidatorData = hash
+		// then, we have a bucket per-peer. this is so peers cant spam requests
+		// endlessly.
+		bucketsMu.Lock()
+		defer bucketsMu.Unlock()
+		b, ok := buckets.Get(id)
+		if !ok {
+			// initialize the new rate bucket for this peer
+			b = &rateBucket{tokens: maxTokens, last: now}
+			buckets.Add(id, b)
+		} else {
+			// otherwise lets see if this bucket needs to be refilled
+			if d := now.Sub(b.last); d > 0 {
+				b.tokens += int(d.Minutes() * float64(refillPerMin))
+				if b.tokens > maxTokens {
+					b.tokens = maxTokens
+				}
+				b.last = now
+			}
+		}
 
+		// we just straight up ignore it if the bucket is empty
+		// it means this peer has sent too many requests.
+		if b.tokens < 1 {
+			return pubsub.ValidationIgnore
+		}
+		b.tokens--
+
+		// mark seen after passing rate limit
+		seenMu.Lock()
+		seenHash.Add(hash, now)
+		seenMu.Unlock()
+		message.ValidatorData = hash
 		return pubsub.ValidationAccept
 	}
 }

--- a/op-node/p2p/gossip.go
+++ b/op-node/p2p/gossip.go
@@ -60,12 +60,6 @@ const (
 var MessageDomainInvalidSnappy = [4]byte{0, 0, 0, 0}
 var MessageDomainValidSnappy = [4]byte{1, 0, 0, 0}
 
-// rateBucket is used to limit the number of messages that can be sent in a given time period.
-type rateBucket struct {
-	tokens int
-	last   time.Time
-}
-
 type GossipSetupConfigurables interface {
 	PeerScoringParams() *ScoringParams
 	// ConfigureGossip creates configuration options to apply to the GossipSub setup
@@ -545,46 +539,36 @@ func BuildPreconfBlocksRequestValidator(log log.Logger, cfg *rollup.Config, runC
 	}
 
 	var bucketsMu sync.Mutex
+	rate := float64(refillPerMin) / 60.0 // tokens per second
 
 	return func(ctx context.Context, id peer.ID, message *pubsub.Message) pubsub.ValidationResult {
 		now := time.Now()
 		hash := common.BytesToHash(message.Data)
 
-		// we use a per hash time window to prevent spam
-		// of the same hash over and over.
-
+		// Per-hash time window: drop repeats for a short window.
 		if t, ok := seenHash.Get(hash); ok && now.Sub(t) < window {
 			return pubsub.ValidationIgnore
 		}
 
-		// then, we have a bucket per-peer. this is so peers cant spam requests
-		// endlessly.
+		// Per-peer token bucket
 		bucketsMu.Lock()
 		defer bucketsMu.Unlock()
+
+		cap := float64(maxTokens)
+
+		// per message (inside bucketsMu.Lock()):
 		b, ok := buckets.Get(id)
 		if !ok {
-			// initialize the new rate bucket for this peer
-			b = &rateBucket{tokens: maxTokens, last: now}
+			b = &rateBucket{credit: cap, last: now}
 			buckets.Add(id, b)
 		} else {
-			// otherwise lets see if this bucket needs to be refilled
-			if d := now.Sub(b.last); d > 0 {
-				b.tokens += int(d.Minutes() * float64(refillPerMin))
-				if b.tokens > maxTokens {
-					b.tokens = maxTokens
-				}
-				b.last = now
-			}
+			refillBucket(b, now, rate, cap)
 		}
-
-		// we just straight up ignore it if the bucket is empty
-		// it means this peer has sent too many requests.
-		if b.tokens < 1 {
+		if !consumeToken(b, 1.0) {
 			return pubsub.ValidationIgnore
 		}
-		b.tokens--
 
-		// mark seen after passing rate limit
+		// Mark seen after passing rate limit.
 		seenHash.Add(hash, now)
 		message.ValidatorData = hash
 		return pubsub.ValidationAccept
@@ -605,54 +589,50 @@ func BuildPreconfBlocksEndOfSequencingRequestValidator(log log.Logger, cfg *roll
 	}
 
 	var bucketsMu sync.Mutex
+	rate := float64(refillPerMin) / 60.0 // tokens per second
 
 	return func(ctx context.Context, id peer.ID, message *pubsub.Message) pubsub.ValidationResult {
 		now := time.Now()
-		// convert message.Data to uint256
 		epoch := big.NewInt(0).SetBytes(message.Data).Uint64()
 
+		// Per-epoch duplicate limiter (cap total seen responses per epoch).
 		seen, ok := epochLRU.Get(epoch)
 		if !ok {
 			seen = new(seenEpochs)
 			seen.epochs = make(map[uint64]uint64)
 			epochLRU.Add(epoch, seen)
 		}
-
 		if count, hasSeen := seen.numSeen(epoch); hasSeen && count > maxResponsesAcceptable {
 			return pubsub.ValidationIgnore
 		}
 
+		// Per-peer token bucket
 		bucketsMu.Lock()
-		defer bucketsMu.Unlock()
+		cap := float64(maxTokens)
+
+		// per message (inside bucketsMu.Lock()):
 		b, ok := buckets.Get(id)
 		if !ok {
-			// initialize the new rate bucket for this peer
-			b = &rateBucket{tokens: maxTokens, last: now}
+			b = &rateBucket{credit: cap, last: now}
 			buckets.Add(id, b)
 		} else {
-			// otherwise lets see if this bucket needs to be refilled
-			if d := now.Sub(b.last); d > 0 {
-				b.tokens += int(d.Minutes() * float64(refillPerMin))
-				if b.tokens > maxTokens {
-					b.tokens = maxTokens
-				}
-				b.last = now
-			}
+			refillBucket(b, now, rate, cap)
 		}
-
-		// we just straight up ignore it if the bucket is empty
-		// it means this peer has sent too many requests in a short period
-		// of time.
-		if b.tokens < 1 {
+		if !consumeToken(b, 1.0) {
 			return pubsub.ValidationIgnore
 		}
-		b.tokens--
 
-		// mark seen only after passing the rate limit
+		if b.credit < 1.0 {
+			bucketsMu.Unlock()
+			return pubsub.ValidationIgnore
+		}
+		b.credit -= 1.0
+		bucketsMu.Unlock()
+
+		// Count only after rate‑limit passes.
 		seen.markSeen(epoch)
 
 		message.ValidatorData = epoch
-
 		return pubsub.ValidationAccept
 	}
 }

--- a/op-node/p2p/gossip.go
+++ b/op-node/p2p/gossip.go
@@ -608,6 +608,7 @@ func BuildPreconfBlocksEndOfSequencingRequestValidator(log log.Logger, cfg *roll
 
 		// Per-peer token bucket
 		bucketsMu.Lock()
+		defer bucketsMu.Unlock()
 		cap := float64(maxTokens)
 
 		// per message (inside bucketsMu.Lock()):
@@ -623,11 +624,9 @@ func BuildPreconfBlocksEndOfSequencingRequestValidator(log log.Logger, cfg *roll
 		}
 
 		if b.credit < 1.0 {
-			bucketsMu.Unlock()
 			return pubsub.ValidationIgnore
 		}
 		b.credit -= 1.0
-		bucketsMu.Unlock()
 
 		// Count only after rate‑limit passes.
 		seen.markSeen(epoch)

--- a/op-node/p2p/gossip.go
+++ b/op-node/p2p/gossip.go
@@ -623,11 +623,6 @@ func BuildPreconfBlocksEndOfSequencingRequestValidator(log log.Logger, cfg *roll
 			return pubsub.ValidationIgnore
 		}
 
-		if b.credit < 1.0 {
-			return pubsub.ValidationIgnore
-		}
-		b.credit -= 1.0
-
 		// Count only after rate‑limit passes.
 		seen.markSeen(epoch)
 

--- a/op-node/p2p/taiko_rate_limiter.go
+++ b/op-node/p2p/taiko_rate_limiter.go
@@ -1,0 +1,51 @@
+package p2p
+
+import "time"
+
+// rateBucket implements a smooth token bucket:
+// - credit: current tokens available (float for smooth refill)
+// - last:   last time we updated credit
+type rateBucket struct {
+	credit float64
+	last   time.Time
+}
+
+// refillBucket updates b.credit based on elapsed time since b.last.
+//   - rate: tokens per second
+//   - max:  maximum tokens allowed (bucket capacity)
+func refillBucket(b *rateBucket, now time.Time, rate, max float64) {
+	if b == nil {
+		return
+	}
+	// Initialize last if zero; keep credit bounded.
+	if b.last.IsZero() {
+		b.last = now
+		if b.credit > max {
+			b.credit = max
+		}
+		return
+	}
+	elapsed := now.Sub(b.last).Seconds()
+	if elapsed <= 0 {
+		// Clock moved backwards or called twice in the same instant: no refill.
+		return
+	}
+	b.credit += elapsed * rate
+	if b.credit > max {
+		b.credit = max
+	}
+	b.last = now
+}
+
+// consumeToken tries to consume `tokens` (usually 1.0).
+// Returns true if successful, false if not enough credit.
+func consumeToken(b *rateBucket, tokens float64) bool {
+	if b == nil {
+		return false
+	}
+	if b.credit+1e-9 < tokens { // small epsilon for float safety
+		return false
+	}
+	b.credit -= tokens
+	return true
+}

--- a/op-node/p2p/taiko_rate_limiter_test.go
+++ b/op-node/p2p/taiko_rate_limiter_test.go
@@ -1,0 +1,108 @@
+package p2p
+
+import (
+	"testing"
+	"time"
+)
+
+const eps = 1e-9
+
+func approxEqual(a, b float64) bool {
+	d := a - b
+	if d < 0 {
+		d = -d
+	}
+	return d < eps
+}
+
+func TestRefillInitializesLastAndBoundsCredit(t *testing.T) {
+	now := time.Unix(1000, 0).UTC()
+	b := &rateBucket{credit: 9999} // overfull
+	refillBucket(b, now, 10.0, 5.0)
+	if !b.last.Equal(now) {
+		t.Fatalf("expected last to be set to now")
+	}
+	if !approxEqual(b.credit, 5.0) {
+		t.Fatalf("expected credit bounded to 5, got %f", b.credit)
+	}
+}
+
+func TestRefillAddsOverTimeAndCaps(t *testing.T) {
+	start := time.Unix(1000, 0).UTC()
+	b := &rateBucket{credit: 0, last: start}
+
+	// 2 seconds at 3 tokens/sec -> +6 tokens, but cap at 5
+	refillBucket(b, start.Add(2*time.Second), 3.0, 5.0)
+	if !approxEqual(b.credit, 5.0) {
+		t.Fatalf("expected credit=5 (capped), got %f", b.credit)
+	}
+}
+
+func TestRefillNoChangeWhenElapsedNonPositive(t *testing.T) {
+	now := time.Unix(2000, 0).UTC()
+	b := &rateBucket{credit: 2.5, last: now}
+
+	// same timestamp
+	refillBucket(b, now, 10.0, 10.0)
+	if !approxEqual(b.credit, 2.5) {
+		t.Fatalf("expected no change, got %f", b.credit)
+	}
+
+	// time earlier than last
+	refillBucket(b, now.Add(-time.Second), 10.0, 10.0)
+	if !approxEqual(b.credit, 2.5) {
+		t.Fatalf("expected no change with negative elapsed, got %f", b.credit)
+	}
+}
+
+func TestConsumeFailsWhenInsufficient(t *testing.T) {
+	b := &rateBucket{credit: 0}
+	if consumeToken(b, 1.0) {
+		t.Fatalf("consume should fail with 0 credit")
+	}
+	if !approxEqual(b.credit, 0.0) {
+		t.Fatalf("credit should remain unchanged on failed consume, got %f", b.credit)
+	}
+}
+
+func TestConsumeAfterRefill(t *testing.T) {
+	start := time.Unix(3000, 0).UTC()
+	b := &rateBucket{credit: 0, last: start}
+	// Refill 0.5 sec at 2 tokens/sec -> +1.0
+	refillBucket(b, start.Add(500*time.Millisecond), 2.0, 5.0)
+	if !approxEqual(b.credit, 1.0) {
+		t.Fatalf("expected credit=1.0, got %f", b.credit)
+	}
+	if !consumeToken(b, 1.0) {
+		t.Fatalf("consume should succeed with 1.0 credit")
+	}
+	if !approxEqual(b.credit, 0.0) {
+		t.Fatalf("expected credit=0 after consume, got %f", b.credit)
+	}
+}
+
+func TestMultipleSmallRefillsAccumulate(t *testing.T) {
+	start := time.Unix(4000, 0).UTC()
+	b := &rateBucket{credit: 0, last: start}
+
+	rate := 1.0 // 1 token/sec
+	max := 5.0
+
+	// 100ms x 5 -> 0.1*5 = 0.5 tokens
+	for i := 1; i <= 5; i++ {
+		refillBucket(b, start.Add(time.Duration(i)*100*time.Millisecond), rate, max)
+	}
+	if !approxEqual(b.credit, 0.5) {
+		t.Fatalf("expected 0.5 tokens after 5x100ms, got %f", b.credit)
+	}
+}
+
+func TestCapIsRespectedAfterManySeconds(t *testing.T) {
+	start := time.Unix(5000, 0).UTC()
+	b := &rateBucket{credit: 0, last: start}
+	// 100 seconds at 0.2 tokens/sec -> 20, but cap at 5
+	refillBucket(b, start.Add(100*time.Second), 0.2, 5.0)
+	if !approxEqual(b.credit, 5.0) {
+		t.Fatalf("expected credit capped at 5, got %f", b.credit)
+	}
+}


### PR DESCRIPTION
Introduce a rate limiting bucket per-peer.

The idea:
- each request consumes a token
- you get 200 tokens per minute
- 200 / 60 (seconds) = 3.33 requests per second allowed sustained, OR a burst of 200, then slow refill

We also introduce a window on the Requests, dropping them, only allowing every 45 seconds per-hash.