### PR TITLE
feat(p2p): rm the hardcoded blacklist

### DIFF
--- a/op-node/p2p/gossip.go
+++ b/op-node/p2p/gossip.go
@@ -802,37 +802,6 @@ func verifyBlockSignature(log log.Logger, cfg *rollup.Config, runCfg GossipRunti
 		}
 		log.Warn("unexpected block authors", "peer", id, "addrs", cfg.P2PSequencerAddresses())
 
-		// check if they are even in the whitelist at all
-		allSequencers := cfg.AllP2PSequencerAddresses()
-		if len(allSequencers) == 0 {
-			log.Warn("no configured p2p sequencer addresses, ignoring gossiped block", "peer", id, "addr", addr)
-			return pubsub.ValidationReject
-		}
-
-		if !slices.Contains(allSequencers, addr) {
-			// someone is trying to gossip blocks but is not even a registered sequencer.
-			// this is a spam attack or misbehaving peer, or someone trying to insert their own
-			// blocks. Rather than deal with this peer and lower their peer score slowly
-			// so they try again, we should just blacklist them immediately.
-			log.Warn("sequencer is not in whitelist, blacklisting", "peer", id, "addr", addr, "allSequencers", allSequencers)
-
-			// we want to block the peer immediately
-			if g := cfg.ConnGater(); g != nil {
-				if err := g.BlockPeer(id); err != nil {
-					log.Warn("failed to block peer in conn gater", "peer", id, "err", err)
-				}
-			}
-
-			// then we want to close any existing connections to the peer via the host.
-			if h := cfg.Host(); h != nil {
-				if err := h.Network().ClosePeer(id); err != nil {
-					log.Warn("failed to close peer connections", "peer", id, "err", err)
-				}
-			}
-
-			return pubsub.ValidationReject
-		}
-
 		return pubsub.ValidationReject
 	}
 

--- a/op-node/p2p/gossip.go
+++ b/op-node/p2p/gossip.go
@@ -23,7 +23,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
 
-	"github.com/ethereum-optimism/optimism/op-node/p2p/gating"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
@@ -72,11 +71,7 @@ type GossipRuntimeConfig interface {
 }
 
 type PreconfGossipRuntimeConfig interface {
-	P2PSequencerAddresses() []common.Address    // CHANGE(taiko): new impl of preconf gossip runtime config
-	AllP2PSequencerAddresses() []common.Address // CHANGE(taiko): new impl of preconf gossip runtime config
-
-	Host() host.Host                           // CHANGE(taiko): new impl of preconf gossip runtime config
-	ConnGater() gating.BlockingConnectionGater // CHANGE(taiko): new impl of preconf gossip runtime config
+	P2PSequencerAddresses() []common.Address // CHANGE(taiko): new impl of preconf gossip runtime config
 }
 
 //go:generate mockery --name GossipMetricer
@@ -817,6 +812,7 @@ func verifyBlockSignature(log log.Logger, cfg *rollup.Config, runCfg GossipRunti
 		log.Warn("unexpected block author", "err", err, "peer", id, "addr", addr, "expected", expected)
 		return pubsub.ValidationReject
 	}
+
 	return pubsub.ValidationAccept
 }
 

--- a/op-node/p2p/host.go
+++ b/op-node/p2p/host.go
@@ -139,9 +139,9 @@ func (e *extraHost) monitorStaticPeers() {
 
 				wg.Add(1)
 				go func(addr *peer.AddrInfo) {
-					e.log.Warn("static peer disconnected, reconnecting", "peer", addr.ID)
+					e.log.Debug("static peer disconnected, reconnecting", "peer", addr.ID)
 					if err := e.dialStaticPeer(ctx, addr); err != nil {
-						e.log.Warn("error reconnecting to static peer", "peer", addr.ID, "err", err)
+						e.log.Debug("error reconnecting to static peer", "peer", addr.ID, "err", err)
 					}
 					wg.Done()
 				}(addr)

--- a/op-node/p2p/sync.go
+++ b/op-node/p2p/sync.go
@@ -333,7 +333,7 @@ func (s *SyncClient) AddPeer(id peer.ID) {
 		return
 	}
 	if _, ok := s.peers[id]; ok {
-		s.log.Warn("cannot register peer for sync duties, peer was already registered", "peer", id)
+		s.log.Debug("cannot register peer for sync duties, peer was already registered", "peer", id)
 		return
 	}
 	s.wg.Add(1)
@@ -351,7 +351,7 @@ func (s *SyncClient) RemovePeer(id peer.ID) {
 	}
 	cancel, ok := s.peers[id]
 	if !ok {
-		s.log.Warn("cannot remove peer from sync duties, peer was not registered", "peer", id)
+		s.log.Debug("cannot remove peer from sync duties, peer was not registered", "peer", id)
 		return
 	}
 	cancel() // once loop exits


### PR DESCRIPTION
can trigger by accident if a block is received before the lookahead is cached. also, remove some annoying logs