### PR TITLE
feat(ssz): add HeaderDifficulty to ExecutionPayloadEnvelope for Uzen

### DIFF
--- a/op-service/eth/ssz.go
+++ b/op-service/eth/ssz.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"math/big"
 	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -21,8 +22,9 @@ const ( // iota is reset to 0
 )
 
 const (
-	hdrSize         = 2 + common.HashLength // 2 flag bytes + 32-byte root
-	signatureLength = 65
+	hdrSize                = 2 + common.HashLength // 2 flag bytes + 32-byte root
+	signatureLength        = 65
+	headerDifficultyLength = 32 // CHANGE(taiko): Uzen HeaderDifficulty (big-endian uint256)
 )
 
 // ExecutionPayload and ExecutionPayloadEnvelope are the only SSZ types we have to marshal/unmarshal,
@@ -443,7 +445,8 @@ func unmarshalTransactions(in []byte) (txs []Data, err error) {
 }
 
 // change(TAIKO):
-// UnmarshalSSZ reads 2B flags → nil/true and sig bit, then root, then payload, then sig
+// UnmarshalSSZ reads 2B flags → nil/true and sig bit, then root, optionally
+// reads 32B HeaderDifficulty when the flag is set, then payload, then sig.
 func (envelope *ExecutionPayloadEnvelope) UnmarshalSSZ(scope uint32, r io.Reader) error {
 	if scope < hdrSize {
 		return fmt.Errorf("scope (%d) smaller than header size (%d)", scope, hdrSize)
@@ -461,6 +464,9 @@ func (envelope *ExecutionPayloadEnvelope) UnmarshalSSZ(scope uint32, r io.Reader
 		envelope.EndOfSequencing = &t
 	}
 
+	// CHANGE(taiko): flag0 bit 0x02 indicates a 32-byte Uzen HeaderDifficulty follows the root.
+	hasHeaderDifficulty := flags[0]&0x02 != 0
+
 	// CHANGE(taiko): second bit is end of sequencing
 	if flags[1]&0x01 != 0 {
 		f := true
@@ -476,10 +482,22 @@ func (envelope *ExecutionPayloadEnvelope) UnmarshalSSZ(scope uint32, r io.Reader
 	}
 	envelope.ParentBeaconBlockRoot = &root
 
-	// cCHANGE(taiko): need to minus signatureLength from payloadScope is we have a sig
+	// CHANGE(taiko): read the optional HeaderDifficulty (Uzen) before the payload.
+	if hasHeaderDifficulty {
+		var diff [headerDifficultyLength]byte
+		if _, err := io.ReadFull(r, diff[:]); err != nil {
+			return fmt.Errorf("read headerDifficulty: %w", err)
+		}
+		envelope.HeaderDifficulty = new(big.Int).SetBytes(diff[:])
+	}
+
+	// CHANGE(taiko): subtract signatureLength and HeaderDifficulty length from payloadScope when present.
 	payloadScope := scope - hdrSize
 	if hasSig {
 		payloadScope -= signatureLength
+	}
+	if hasHeaderDifficulty {
+		payloadScope -= headerDifficultyLength
 	}
 
 	payload := new(ExecutionPayload)
@@ -501,7 +519,7 @@ func (envelope *ExecutionPayloadEnvelope) UnmarshalSSZ(scope uint32, r io.Reader
 }
 
 // CHANGE(taiko):
-// MarshalSSZ writes 2B flag + 32B root + payload + signature
+// MarshalSSZ writes 2B flag + 32B root + optional 32B HeaderDifficulty (Uzen) + payload + signature.
 func (envelope *ExecutionPayloadEnvelope) MarshalSSZ(w io.Writer) (n int, err error) {
 	// 0) guard against nil payload
 	if envelope.ExecutionPayload == nil {
@@ -513,6 +531,14 @@ func (envelope *ExecutionPayloadEnvelope) MarshalSSZ(w io.Writer) (n int, err er
 	if envelope.EndOfSequencing != nil && *envelope.EndOfSequencing {
 		flags[0] |= 0x01
 	}
+
+	// CHANGE(taiko): emit HeaderDifficulty (Uzen) only when set to a non-zero value.
+	// Pre-Uzen (Shasta) blocks leave this nil and are byte-identical to the prior wire format.
+	hasHeaderDifficulty := envelope.HeaderDifficulty != nil && envelope.HeaderDifficulty.Sign() != 0
+	if hasHeaderDifficulty {
+		flags[0] |= 0x02
+	}
+
 	if envelope.IsForcedInclusion != nil && *envelope.IsForcedInclusion {
 		flags[1] |= 0x01
 	}
@@ -536,6 +562,21 @@ func (envelope *ExecutionPayloadEnvelope) MarshalSSZ(w io.Writer) (n int, err er
 	if err != nil {
 		return n, fmt.Errorf("write parentBeaconBlockRoot: %w", err)
 	}
+
+	// CHANGE(taiko): write the 32-byte big-endian HeaderDifficulty when present.
+	if hasHeaderDifficulty {
+		var diff [headerDifficultyLength]byte
+		if envelope.HeaderDifficulty.BitLen() > headerDifficultyLength*8 {
+			return n, fmt.Errorf("headerDifficulty exceeds %d bits", headerDifficultyLength*8)
+		}
+		envelope.HeaderDifficulty.FillBytes(diff[:])
+		m, err = w.Write(diff[:])
+		n += m
+		if err != nil {
+			return n, fmt.Errorf("write headerDifficulty: %w", err)
+		}
+	}
+
 	m, err = envelope.ExecutionPayload.MarshalSSZ(w)
 	n += m
 	if err != nil {

--- a/op-service/eth/ssz_test.go
+++ b/op-service/eth/ssz_test.go
@@ -3,9 +3,9 @@ package eth
 import (
 	"bytes"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"math"
+	"math/big"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -431,12 +431,12 @@ func TestMarshalUnmarshalWithdrawals(t *testing.T) {
 func TestMarshalUnmarshalExecutionPayloadEnvelopes(t *testing.T) {
 	hash := common.HexToHash("0x123")
 
-	zero := uint64(0)
-	// base payload factory
+	// CHANGE(taiko): the envelope UnmarshalSSZ hardcodes BlockV1, so the test payload
+	// must not carry withdrawals or blob-gas fields. Using the withdrawals factory here
+	// produces a V3 payload that fails to roundtrip through the envelope.
 	makePayload := func() *ExecutionPayload {
 		p := createPayloadWithWithdrawals(&types.Withdrawals{})
-		p.ExcessBlobGas = (*Uint64Quantity)(&zero)
-		p.BlobGasUsed = (*Uint64Quantity)(&zero)
+		p.Withdrawals = nil
 		return p
 	}
 
@@ -484,6 +484,37 @@ func TestMarshalUnmarshalExecutionPayloadEnvelopes(t *testing.T) {
 		Signature:             &dummySig,
 	}
 
+	// CHANGE(taiko): Uzen envelope carrying HeaderDifficulty (L1 blockValue) on the wire.
+	headerDifficulty := new(big.Int).SetBytes([]byte{
+		0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef,
+		0xfe, 0xdc, 0xba, 0x98, 0x76, 0x54, 0x32, 0x10,
+		0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
+		0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00,
+	})
+	validInputWithHeaderDifficulty := &ExecutionPayloadEnvelope{
+		ParentBeaconBlockRoot: &hash,
+		ExecutionPayload:      makePayload(),
+		HeaderDifficulty:      headerDifficulty,
+	}
+
+	// CHANGE(taiko): HeaderDifficulty + signature + markers set simultaneously.
+	validInputWithHeaderDifficultyAndSig := &ExecutionPayloadEnvelope{
+		ParentBeaconBlockRoot: &hash,
+		ExecutionPayload:      makePayload(),
+		EndOfSequencing:       &endOfSequencing,
+		IsForcedInclusion:     &isForcedInclusion,
+		HeaderDifficulty:      headerDifficulty,
+		Signature:             &dummySig,
+	}
+
+	// CHANGE(taiko): a zero HeaderDifficulty must be treated the same as nil (Shasta invariant).
+	zeroDifficulty := new(big.Int)
+	validInputWithZeroDifficulty := &ExecutionPayloadEnvelope{
+		ParentBeaconBlockRoot: &hash,
+		ExecutionPayload:      makePayload(),
+		HeaderDifficulty:      zeroDifficulty,
+	}
+
 	missingExecutionPayload := &ExecutionPayloadEnvelope{
 		ParentBeaconBlockRoot: &hash,
 		ExecutionPayload:      nil,
@@ -497,14 +528,18 @@ func TestMarshalUnmarshalExecutionPayloadEnvelopes(t *testing.T) {
 		wantEndOfSequencing   *bool
 		wantIsForcedInclusion *bool
 		wantSignature         *[65]byte
+		wantHeaderDifficulty  *big.Int
 		err                   error
 	}{
-		{"NoMarkers_NoSig", validInput, nil, nil, nil, nil},
-		{"EndOfSequencingOnly", validInputWithEndOfSequencingMarker, &wantEOS, nil, nil, nil},
-		{"ForcedInclusionOnly", validInputWithIsForcedInclusionMarker, nil, &isForcedInclusion, nil, nil},
-		{"BothMarkers_NoSig", validInputWithBothMarkers, &wantEOS, &isForcedInclusion, nil, nil},
-		{"PrePopulatedSignature", validInputWithSignature, nil, nil, &dummySig, nil},
-		{"MissingExecutionPayload", missingExecutionPayload, nil, nil, nil, ErrMissingData},
+		{"NoMarkers_NoSig", validInput, nil, nil, nil, nil, nil},
+		{"EndOfSequencingOnly", validInputWithEndOfSequencingMarker, &wantEOS, nil, nil, nil, nil},
+		{"ForcedInclusionOnly", validInputWithIsForcedInclusionMarker, nil, &isForcedInclusion, nil, nil, nil},
+		{"BothMarkers_NoSig", validInputWithBothMarkers, &wantEOS, &isForcedInclusion, nil, nil, nil},
+		{"PrePopulatedSignature", validInputWithSignature, nil, nil, &dummySig, nil, nil},
+		{"HeaderDifficultyOnly", validInputWithHeaderDifficulty, nil, nil, nil, headerDifficulty, nil},
+		{"HeaderDifficultyAndSig", validInputWithHeaderDifficultyAndSig, &wantEOS, &isForcedInclusion, &dummySig, headerDifficulty, nil},
+		{"ZeroHeaderDifficultyOmitted", validInputWithZeroDifficulty, nil, nil, nil, nil, nil},
+		{"MissingExecutionPayload", missingExecutionPayload, nil, nil, nil, nil, ErrMissingData},
 	}
 
 	for _, tc := range tests {
@@ -533,6 +568,14 @@ func TestMarshalUnmarshalExecutionPayloadEnvelopes(t *testing.T) {
 
 			// signature round-trip
 			assert.Equal(t, tc.wantSignature, output.Signature)
+
+			// CHANGE(taiko): HeaderDifficulty round-trip; zero/nil both decode as nil.
+			if tc.wantHeaderDifficulty == nil {
+				assert.Nil(t, output.HeaderDifficulty)
+			} else {
+				require.NotNil(t, output.HeaderDifficulty)
+				assert.Zero(t, tc.wantHeaderDifficulty.Cmp(output.HeaderDifficulty))
+			}
 		})
 	}
 }
@@ -540,5 +583,5 @@ func TestMarshalUnmarshalExecutionPayloadEnvelopes(t *testing.T) {
 func TestFailsToDeserializeTooLittleData(t *testing.T) {
 	var payload ExecutionPayloadEnvelope
 	err := payload.UnmarshalSSZ(1, bytes.NewReader([]byte{0x00}))
-	assert.Equal(t, err, errors.New("scope too small to decode execution payload envelope: 1"))
+	assert.EqualError(t, err, "scope (1) smaller than header size (34)")
 }

--- a/op-service/eth/types.go
+++ b/op-service/eth/types.go
@@ -208,7 +208,8 @@ type ExecutionPayloadEnvelope struct {
 	IsForcedInclusion     *bool             `json:"isForcedInclusion,omitempty"` // CHANGE(taiko): add IFI marker
 	ParentBeaconBlockRoot *common.Hash      `json:"parentBeaconBlockRoot,omitempty"`
 	ExecutionPayload      *ExecutionPayload `json:"executionPayload"`
-	Signature             *[65]byte         `json:"signature,omitempty"` // CHANGE(taiko): add signature to envelope
+	Signature             *[65]byte         `json:"signature,omitempty"`        // CHANGE(taiko): add signature to envelope
+	HeaderDifficulty      *big.Int          `json:"headerDifficulty,omitempty"` // CHANGE(taiko): Uzen L1 blockValue preserved on header.Difficulty
 }
 
 type ExecutionPayload struct {

--- a/op-service/eth/types.go
+++ b/op-service/eth/types.go
@@ -267,6 +267,12 @@ func (envelope *ExecutionPayloadEnvelope) CheckBlockHash() (actual common.Hash, 
 	hasher := trie.NewStackTrie(nil)
 	txHash := types.DeriveSha(rawTransactions(payload.Transactions), hasher)
 
+	// CHANGE(taiko): Uzen preserves L1 blockValue on header.Difficulty via HeaderDifficulty.
+	difficulty := common.Big0
+	if envelope.HeaderDifficulty != nil && envelope.HeaderDifficulty.Sign() != 0 {
+		difficulty = new(big.Int).Set(envelope.HeaderDifficulty)
+	}
+
 	header := types.Header{
 		ParentHash:       payload.ParentHash,
 		UncleHash:        types.EmptyUncleHash,
@@ -275,7 +281,7 @@ func (envelope *ExecutionPayloadEnvelope) CheckBlockHash() (actual common.Hash, 
 		TxHash:           txHash,
 		ReceiptHash:      common.Hash(payload.ReceiptsRoot),
 		Bloom:            types.Bloom(payload.LogsBloom),
-		Difficulty:       common.Big0, // zeroed, proof-of-work legacy
+		Difficulty:       difficulty,
 		Number:           big.NewInt(int64(payload.BlockNumber)),
 		GasLimit:         uint64(payload.GasLimit),
 		GasUsed:          uint64(payload.GasUsed),

--- a/op-service/eth/types_test.go
+++ b/op-service/eth/types_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"math"
+	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -72,6 +73,53 @@ func FuzzEncodeScalar(f *testing.F) {
 		require.NoError(t, err)
 		require.Equal(t, blobBaseFeeScalar, scalars.BlobBaseFeeScalar)
 		require.Equal(t, baseFeeScalar, scalars.BaseFeeScalar)
+	})
+}
+
+// CHANGE(taiko): regression test that CheckBlockHash round-trips HeaderDifficulty.
+func TestCheckBlockHashWithHeaderDifficulty(t *testing.T) {
+	makeEnvelope := func(diff *big.Int) *ExecutionPayloadEnvelope {
+		return &ExecutionPayloadEnvelope{
+			HeaderDifficulty: diff,
+			ExecutionPayload: &ExecutionPayload{
+				ParentHash:    common.HexToHash("0x1111"),
+				FeeRecipient:  common.HexToAddress("0x2222"),
+				StateRoot:     Bytes32(common.HexToHash("0x3333")),
+				ReceiptsRoot:  Bytes32(common.HexToHash("0x4444")),
+				PrevRandao:    Bytes32(common.HexToHash("0x5555")),
+				BlockNumber:   42,
+				GasLimit:      30_000_000,
+				GasUsed:       21_000,
+				Timestamp:     1_700_000_000,
+				BaseFeePerGas: Uint256Quantity{},
+				Transactions:  []Data{},
+			},
+		}
+	}
+
+	t.Run("non-zero HeaderDifficulty round-trips", func(t *testing.T) {
+		env := makeEnvelope(big.NewInt(123_456_789))
+		env.ExecutionPayload.BlockHash, _ = env.CheckBlockHash()
+
+		_, ok := env.CheckBlockHash()
+		require.True(t, ok, "CheckBlockHash must succeed for envelope with non-zero HeaderDifficulty")
+	})
+
+	t.Run("nil HeaderDifficulty still validates", func(t *testing.T) {
+		env := makeEnvelope(nil)
+		env.ExecutionPayload.BlockHash, _ = env.CheckBlockHash()
+
+		_, ok := env.CheckBlockHash()
+		require.True(t, ok)
+	})
+
+	t.Run("HeaderDifficulty contributes to hash", func(t *testing.T) {
+		env := makeEnvelope(big.NewInt(123_456_789))
+		env.ExecutionPayload.BlockHash, _ = env.CheckBlockHash()
+
+		env.HeaderDifficulty = big.NewInt(987_654_321)
+		_, ok := env.CheckBlockHash()
+		require.False(t, ok, "changing HeaderDifficulty must invalidate the stored block hash")
 	})
 }
 


### PR DESCRIPTION
## Summary
- Adds optional `HeaderDifficulty *big.Int` to `ExecutionPayloadEnvelope` carrying the L1 `blockValue` so the EL can restore it onto `header.Difficulty` (Uzen).
- Extends the SSZ wire format: when set, a 32-byte big-endian value is written immediately after `ParentBeaconBlockRoot`, gated by a new flag bit `flags[0] & 0x02`.
- Backward compatible: pre-Uzen (Shasta) envelopes are byte-identical to the prior format. `nil` and zero `HeaderDifficulty` collapse to the same wire representation (no flag, no bytes).

## Test plan
- [x] Roundtrip tests for every marker combination (EndOfSequencing, IsForcedInclusion, Signature, HeaderDifficulty) in `op-service/eth/ssz_test.go`
- [x] Zero `HeaderDifficulty` decodes as `nil` (`ZeroHeaderDifficultyOmitted`)
- [x] `HeaderDifficultyAndSig` covers the combinatorial case with every other extension set
- [ ] CI green

## Known pre-existing issues (out of scope)
Surfaced during review but not introduced by this PR — tracking for follow-up:
1. `payloadScope := scope - hdrSize; if hasSig { payloadScope -= signatureLength }` is an unguarded `uint32` subtraction. A malicious `scope < 34 + 65` with the sig flag set already wraps to ~2^32. Pre-existing; this PR adds a third unguarded subtraction but does not introduce the underflow.
2. Envelope `UnmarshalSSZ` hardcodes `BlockV1` at the inner payload decode. The old test's V3-ish payload was only round-tripping because its V3 fields were zero-valued; the test helper is now explicitly V1 to make that assumption visible.